### PR TITLE
Allow sync of user details from AAD, new user creation will populate from AAD

### DIFF
--- a/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/AADAuthenticationScheme.java
+++ b/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/AADAuthenticationScheme.java
@@ -34,6 +34,8 @@ public class AADAuthenticationScheme extends HttpAuthenticationSchemeAdapter {
   private static final String NAME_CLAIM = "unique_name";
   private static final String OID_CLAIM = "oid"; //object ID
   private static final String EMAIL_CLAIM = "upn";
+  private static final String FAMILY_NAME_CLAIM = "family_name";
+  private static final String GIVEN_NAME_CLAIM = "given_name";
   private static final String ERROR_CLAIM = "error";
   private static final String ERROR_DESCRIPTION_CLAIM = "error_description";
 
@@ -119,10 +121,13 @@ public class AADAuthenticationScheme extends HttpAuthenticationSchemeAdapter {
       return sendBadRequest(response, "Marked request as unauthenticated since retrieved JWT 'nonce' claim doesn't correspond to current TeamCity session.");
 
     final String email = token.getClaim(EMAIL_CLAIM);
+    final String surname = token.getClaim(FAMILY_NAME_CLAIM);
+    final String firstname = token.getClaim(GIVEN_NAME_CLAIM);
+    final String displayName = firstname + " " + surname;
 
-    final ServerPrincipal principal = myPrincipalFactory.getServerPrincipal(name, oid, email, schemeProperties);
-
+    final ServerPrincipal principal = myPrincipalFactory.getServerPrincipal(name, oid, displayName, email, schemeProperties);
     LOG.debug("Request authenticated. Determined user " + principal.getName());
+
     return HttpAuthenticationResult.authenticated(principal, HttpAuthRememberMeUtil.mustRememberMe());
   }
 

--- a/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/ServerPrincipalFactory.java
+++ b/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/ServerPrincipalFactory.java
@@ -1,11 +1,9 @@
 package org.jetbrains.teamcity.aad;
 
+import jetbrains.buildServer.PluginTypes;
 import jetbrains.buildServer.serverSide.auth.AuthModuleUtil;
 import jetbrains.buildServer.serverSide.auth.ServerPrincipal;
-import jetbrains.buildServer.users.PropertyKey;
-import jetbrains.buildServer.users.SUser;
-import jetbrains.buildServer.users.UserModel;
-import jetbrains.buildServer.users.UserSet;
+import jetbrains.buildServer.users.*;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,6 +21,7 @@ public class ServerPrincipalFactory {
 
   private static final boolean DEFAULT_ALLOW_CREATING_NEW_USERS_BY_LOGIN = true;
   private static final String ALLOW_MATCHING_USERS_BY_EMAIL = "allowMatchingUsersByEmail";
+  private static final String ALLOW_USER_DETAILS_SYNC = "allowUserDetailsSync";
 
   @NotNull private final UserModel myUserModel;
 
@@ -31,25 +30,42 @@ public class ServerPrincipalFactory {
   }
 
   @NotNull
-  public ServerPrincipal getServerPrincipal(@NotNull String userName, @NotNull final String aadUserUID, @Nullable final String email, @NotNull Map<String, String> schemeProperties) {
-    final ServerPrincipal existingPrincipal = findExistingPrincipalByUID(aadUserUID);
-    if(existingPrincipal != null) return existingPrincipal;
+  public ServerPrincipal getServerPrincipal(@NotNull String userName, @NotNull final String aadUserUID, @Nullable final String displayName, @Nullable final String email, @NotNull Map<String, String> schemeProperties) {
+    // Match by UID
+    final SUser userWithTheSameUID = findExistingUserByUID(aadUserUID);
+    if (userWithTheSameUID != null) {
+      if(allowUserDetailsSync(schemeProperties)) {
+          userWithTheSameUID.updateUserAccount(userName, displayName, email);
+      }
+      return new ServerPrincipal(AADConstants.AAD_AUTH_SCHEME_NAME, userWithTheSameUID.getUsername());
+    }
 
+    // Match by email
     if(email != null && allowMatchUserByEmail(schemeProperties)){
       final SUser userWithTheSameEmail = findExistingUserByEmail(email);
       if(userWithTheSameEmail != null){
-        final String username = userWithTheSameEmail.getUsername();
-        LOG.info(String.format("Associated aad user %s with TeamCity user %s by email %s", userName, username, email));
+        final String usernameFound = userWithTheSameEmail.getUsername();
+        LOG.info(String.format("Associated aad user %s with TeamCity user %s by email %s", userName, usernameFound, email));
         userWithTheSameEmail.setUserProperty(AADConstants.OID_USER_PROPERTY_KEY, aadUserUID);
-        return new ServerPrincipal(AADConstants.AAD_AUTH_SCHEME_NAME, username);
+        if(allowUserDetailsSync(schemeProperties)) {
+          userWithTheSameEmail.updateUserAccount(userName, displayName, email);
+        }
+        return new ServerPrincipal(AADConstants.AAD_AUTH_SCHEME_NAME, userWithTheSameEmail.getUsername());
       }
     }
 
+    // Create user and populate with users details
     final boolean allowCreatingNewUsersByLogin = AuthModuleUtil.allowCreatingNewUsersByLogin(schemeProperties, DEFAULT_ALLOW_CREATING_NEW_USERS_BY_LOGIN);
     final HashMap<PropertyKey, String> userProperties = new HashMap<PropertyKey, String>() {{
       put(AADConstants.OID_USER_PROPERTY_KEY, aadUserUID);
     }};
-    return new ServerPrincipal(AADConstants.AAD_AUTH_SCHEME_NAME, userName, null, allowCreatingNewUsersByLogin, userProperties);
+
+    if (allowCreatingNewUsersByLogin) {
+      SUser createUser = myUserModel.createUserAccount(AADConstants.AAD_AUTH_SCHEME_NAME, userName);
+      createUser.updateUserAccount(userName, displayName, email);
+      createUser.setUserProperty(AADConstants.OID_USER_PROPERTY_KEY, aadUserUID);
+    }
+   return new ServerPrincipal(AADConstants.AAD_AUTH_SCHEME_NAME, userName, null, allowCreatingNewUsersByLogin, userProperties);
   }
 
   @Nullable
@@ -61,12 +77,12 @@ public class ServerPrincipalFactory {
   }
 
   @Nullable
-  private ServerPrincipal findExistingPrincipalByUID(@NotNull final String userUID) {
-    final UserSet<SUser> userSet = myUserModel.findUsersByPropertyValue(AADConstants.OID_USER_PROPERTY_KEY, userUID, true);
-    final Set<SUser> users = userSet.getUsers();
+  private SUser findExistingUserByUID(@NotNull String userUID) {
+    UserSet<SUser> userSet = myUserModel.findUsersByPropertyValue(AADConstants.OID_USER_PROPERTY_KEY, userUID, true);
+    Set<SUser> users = userSet.getUsers();
     if (!users.isEmpty()) {
-      final SUser user = users.iterator().next();
-      return new ServerPrincipal(AADConstants.AAD_AUTH_SCHEME_NAME, user.getUsername());
+      SUser user = users.iterator().next();
+      return user;
     }
     return null;
   }
@@ -75,4 +91,10 @@ public class ServerPrincipalFactory {
     Object value = schemeProperties.get(ALLOW_MATCHING_USERS_BY_EMAIL);
     return value != null && Boolean.parseBoolean((String) value);
   }
+
+  private static boolean allowUserDetailsSync(Map<String, String> schemeProperties) {
+    Object value = schemeProperties.get(ALLOW_USER_DETAILS_SYNC);
+    return value != null && Boolean.parseBoolean((String) value);
+  }
+
 }

--- a/azure-active-directory-server/src/main/resources/buildServerResources/editAADSchemeProperties.jsp
+++ b/azure-active-directory-server/src/main/resources/buildServerResources/editAADSchemeProperties.jsp
@@ -4,6 +4,11 @@
 <div><jsp:include page="/admin/allowCreatingNewUsersByLogin.jsp"/></div>
 <br/>
 <div>
+    <prop:checkboxProperty name="allowUserDetailsSync" uncheckedValue="false"/>
+    <label width="100%" for="allowUserDetailsSync">Allow synchronization of user details with Azure when logging in</label>
+</div>
+<br/>
+<div>
     <prop:checkboxProperty name="allowMatchingUsersByEmail" uncheckedValue="false"/>
     <label width="100%" for="allowMatchingUsersByEmail">Allow matching users by Email</label>
 </div>


### PR DESCRIPTION
Add in support to allow sync of user details from AAD.
New user creation will also create new user with AAD details. 

Implementation of #8 