### PR TITLE
Remove Sing-on URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,8 +20,7 @@ Register a new [Azure Active Directory application](https://docs.microsoft.com/e
 
 | Parameter        | Value                          |
 | -                | -                              |
-| Application type | Web app / API                  |
-| Sign-on URL      | `%TEAMCITY_URL%/login.html`    |
+| Application type | Web                            |
 | Redirect URIs    | `%TEAMCITY_URL%/overview.html` |
 |                  | `%TEAMCITY_URL%/aadAuth.html`  |
 


### PR DESCRIPTION
Sign-on URL is no longer an option when creating an App Registration