### PR TITLE
Allow to define custom endpoint with signing keys

### DIFF
--- a/azure-active-directory-server/src/main/kotlin/org/jetbrains/teamcity/aad/JWTVerifier.kt
+++ b/azure-active-directory-server/src/main/kotlin/org/jetbrains/teamcity/aad/JWTVerifier.kt
@@ -17,13 +17,11 @@
 package org.jetbrains.teamcity.aad
 
 import jetbrains.buildServer.serverSide.TeamCityProperties
-import jetbrains.buildServer.util.StringUtil
 import org.jose4j.http.Get
 import org.jose4j.jwk.HttpsJwks
 import org.jose4j.jwt.JwtClaims
 import org.jose4j.jwt.consumer.JwtConsumerBuilder
 import org.jose4j.keys.resolvers.HttpsJwksVerificationKeyResolver
-import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
 import java.util.concurrent.atomic.AtomicReference
@@ -33,6 +31,7 @@ object JWTVerifier {
     private val TC_HTTPS_PROXY_PORT = "teamcity.https.proxyPort"
     private val HTTPS_PROXY_HOST = "https.proxyHost"
     private val HTTPS_PROXY_PORT = "https.proxyPort"
+    private val CUSTOM_JWT_SIGNING_KEYS_ENDPOINT = "teamcity.aad.signingKeys.endpoint"
 
     private val JWT_AAD_SIGNING_KEYS_ENDPOINT = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/discovery/v2.0/keys"
     private val httpJwksHolder = AtomicReference<HttpsJwksHolder?>()
@@ -70,7 +69,7 @@ object JWTVerifier {
             } else {
                 HttpsJwksHolder(
                         proxyDescriptor,
-                        HttpsJwks(JWT_AAD_SIGNING_KEYS_ENDPOINT).also {
+                        HttpsJwks(getSigningKeysEndpoint()).also {
                             if (proxyDescriptor.proxyHost?.isNotBlank() ?: false) {
                                 it.setSimpleHttpGet(Get().also {
                                     it.setHttpProxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyHost, proxyPort)))
@@ -80,6 +79,10 @@ object JWTVerifier {
                 )
             }
         }!!.httpJwks
+    }
+
+    private fun getSigningKeysEndpoint(): String {
+        return TeamCityProperties.getProperty(CUSTOM_JWT_SIGNING_KEYS_ENDPOINT, JWT_AAD_SIGNING_KEYS_ENDPOINT)
     }
 
     private fun <T> getFirstTeamCityProperty(vararg propertyNames: String, getter: (String) -> T?): T? {

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ Possible solutions:
 #### Authentication fails with HTTP 400: Failed to parse JWT
 
 If your AAD application has custom signing keys as a result of using the claims-mapping feature you may experience this error. 
+You may also find exception like _org.jose4j.lang.UnresolvableKeyException: Unable to find a suitable verification key for JWS w/ header_ in logfile `teamcity-winservice.log`. 
 Based on [Microsoft documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#validating-the-signature) you need to get custom JWT signing keys for validation.
 To achieve this you need to define [internal property](https://confluence.jetbrains.com/display/TCDL/Configuring+TeamCity+Server+Startup+Properties) `teamcity.aad.signingKeys.endpoint` with value of `https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys?appid=<app-id>`.
 Please also ensure that your TeamCity server instance can reach out to the mentioned server.

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,13 @@ Possible solutions:
 * Use HTTPS for TeamCity server and specify it in the Azure AD application settings
 * For testing, you can specify the [internal property](https://confluence.jetbrains.com/display/TCDL/Configuring+TeamCity+Server+Startup+Properties) `rest.cors.origins=null` (**insecure, don't use it in production**)
 
+#### Authentication fails with HTTP 400: Failed to parse JWT
+
+If your AAD application has custom signing keys as a result of using the claims-mapping feature you may experience this error. 
+Based on [Microsoft documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#validating-the-signature) you need to get custom JWT signing keys for validation.
+To achieve this you need to define [internal property](https://confluence.jetbrains.com/display/TCDL/Configuring+TeamCity+Server+Startup+Properties) `teamcity.aad.signingKeys.endpoint` with value of `https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys?appid=<app-id>`.
+Please also ensure that your TeamCity server instance can reach out to the mentioned server.
+
 ## How it works?
 
 This plugin uses the [OAuth 2.0 OpenID Connect](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-openid-connect-code) authentication protocol and works as follows:


### PR DESCRIPTION
This may be fix for the issue #56.

PR adds possibility to define custom URL where JWT signing keys can be obtained from instead of using default location.