### PR TITLE
Azure AD plugin support for v2 OAuth 2.0 authorization endpoint

### DIFF
--- a/azure-active-directory-server/src/main/kotlin/org/jetbrains/teamcity/aad/LoginViaAADController.kt
+++ b/azure-active-directory-server/src/main/kotlin/org/jetbrains/teamcity/aad/LoginViaAADController.kt
@@ -37,7 +37,7 @@ class LoginViaAADController(webManager: WebControllerManager,
         val requestUrl = StringBuilder("$endpoint$separator")
                 .append("response_type=id_token")
                 .append("&client_id=$clientId")
-                .append("&scope=openid")
+                .append("&scope=openid profile")
                 .append("&nonce=$nonce")
                 .append("&response_mode=form_post")
                 .apply {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/TW-66221
- added "profile" to scope in login request, using "upn" instead of "unique_name" in case of v2.0

Tested on our On-Prem Teamcity with Entra ID v2 endpoint